### PR TITLE
rudimentary c parser

### DIFF
--- a/1.23.c
+++ b/1.23.c
@@ -41,14 +41,14 @@ int main(void)
                 break;
             case COMMENT:
                 /* From the comment state we can only exit back into the normal 
-		 * state. We can not have come from the comment single quote 
-		 * state and we could also not have come from the double quote state 
-		 * since those both do not allow entering the comment state. */
+                 * state. We can not have come from the comment single quote 
+                 * state and we could also not have come from the double quote state 
+                 * since those both do not allow entering the comment state. */
                 assert(prevstate == NORMAL);
                 if (prevchar == '*' && c == '/') {
                     change_state(prevstate);
-		    prevchar = '\0';
-		    c = '\0';
+                    prevchar = '\0';
+                    c = '\0';
                 }
                 break;
             case SINGLEQ:
@@ -59,23 +59,23 @@ int main(void)
                  * definition only one char long, we should also never enter 
                  * the comment state.*/
                 assert(prevstate == NORMAL);
-		if (c == '\'') {
-		    if (prevchar != '\\' || prevprevchar == '\\') {
+                if (c == '\'') {
+                    if (prevchar != '\\' || prevprevchar == '\\') {
                         change_state(NORMAL);
-		    }
-		}
+                    }
+                }
                 break;
             case DOUBLEQ:
                 /* From the double quote state we can only revert back into the 
-		 * normal state since we can't enter a comment state from within
-		 * a multi-line comment. Additionally, we can not have come from 
-		 * the single quote state. */
-                assert(prevstate != SINGLEQ);
-		if (c == '"') {
-		    if (prevchar != '\\' || prevprevchar == '\\') {
+                 * normal state since we can't enter a comment state from within
+                 * a multi-line comment. Additionally, we can not have come from 
+                 * the single quote state. */
+                assert(prevstate == NORMAL);
+                if (c == '"') {
+                    if (prevchar != '\\' || prevprevchar == '\\') {
                         change_state(NORMAL);
-		    }
-		}
+                    }
+                }
                 break;
         }
         /* print the previous character if not in comment */

--- a/1.24.c
+++ b/1.24.c
@@ -67,11 +67,12 @@ void enter_state(int new_state)
     enterline[nest_level] = lines + 1;
 }
 
-void exit_state()
+void exit_state(int state_to_exit)
 {
     /* Drop a state from the stack */
     extern int state[MAXNESTED];
     extern int nest_level;
+	/* todo: throw error when state_to_exit not in stack */
     state[nest_level] = '\0';
     nest_level--;
 }
@@ -111,6 +112,87 @@ void shift_read_character()
     prevchar = c;
 }
 
+void handle_re_entrant_state()
+{
+	/* From the a re-entrant state we can enter the comment state, 
+	 * the single quote state and the double quote state. We can also
+	 * enter the parenthesis, brackets and braces states. Those last 
+	 * three can be nested */
+	if (detect_entering_comment()) {
+		enter_state(COMMENT);
+	} else if (detect_state_change('\'')) {
+		enter_state(SINGLEQ);
+	} else if (detect_state_change('"')) {
+		enter_state(DOUBLEQ);
+	} else if (detect_state_change('(')) {
+		enter_state(PARENTH);
+	} else if (detect_state_change(')')) {
+		exit_state(PARENTH);
+	} else if (detect_state_change('[')) {
+		enter_state(BRACKET);
+	} else if (detect_state_change(']')) {
+		exit_state(BRACKET);
+	} else if (detect_state_change('{')) {
+		enter_state(CURLIES);
+	} else if (detect_state_change('}')) {
+		exit_state(CURLIES);
+	}
+}
+
+void handle_comment()
+{
+	/* From the comment state we can only exit back into the normal 
+	 * state. We can not have come from the comment single quote 
+	 * state and we could also not have come from the double quote state 
+	 * since those both do not allow entering the comment state. */
+	if (detect_leaving_comment()) {
+		exit_state(COMMENT);
+		if (get_current_state() == SINGLEQ || get_current_state() == DOUBLEQ) {
+			fprintf(
+				stderr, 
+				"Could not parse comment at line %d\n",
+				lines
+			);
+			exit(150);
+		}
+	}
+}
+
+void handle_q(char delimiter, int state, int check, char msg[], int code)
+{
+	if (detect_state_change(delimiter)) {
+		exit_state(state);
+		if (get_current_state() == check) {
+			fprintf(
+					stderr, 
+					"%s at line %d\n",
+					msg, lines
+				   );
+			exit(code);
+		}
+	}
+}
+
+void handle_singleq()
+{
+	/* From the single quote state we can exit back into the 
+	 * normal state. The previous state should only be the normal 
+	 * state since the char constant of double quote should not 
+	 * change the state. And because character constants are by 
+	 * definition only one char long, we should also never enter 
+	 * the comment state.*/
+	handle_q('\'', SINGLEQ, DOUBLEQ, "Could not parse single quotes", 151);
+}
+
+void handle_doubleq()
+{
+	/* From the double quote state we can only revert back into the 
+	 * normal state since we can't enter a comment state from within
+	 * a multi-line comment. Additionally, we can not have come from 
+	 * the single quote state. */
+	handle_q('"', DOUBLEQ, SINGLEQ, "Could not parse double quotes", 152);
+}
+
 void initialize_state_machine()
 {
     while ((c = getchar()) != EOF) {
@@ -118,69 +200,17 @@ void initialize_state_machine()
             lines++;
         }
         switch(get_current_state()) {
-            case NORMAL:
-                /* From the normal state we can enter the comment state, 
-                 * the single quote state and the double quote state. */
-                if (detect_entering_comment()) {
-                    enter_state(COMMENT);
-                } else if (detect_state_change('\'')) {
-                    enter_state(SINGLEQ);
-                } else if (detect_state_change('"')) {
-                    enter_state(DOUBLEQ);
-                }
+            case NORMAL: case PARENTH: case BRACKET: case CURLIES:
+				handle_re_entrant_state();
                 break;
             case COMMENT:
-                /* From the comment state we can only exit back into the normal 
-                 * state. We can not have come from the comment single quote 
-                 * state and we could also not have come from the double quote state 
-                 * since those both do not allow entering the comment state. */
-                if (detect_leaving_comment()) {
-                    exit_state();
-                    if (get_current_state() != NORMAL) {
-                        fprintf(
-                            stderr, 
-                            "Could not parse comment at line %d\n",
-                            lines
-                        );
-                        exit(150);
-                    }
-                }
+				handle_comment();
                 break;
             case SINGLEQ:
-                /* From the single quote state we can exit back into the 
-                 * normal state. The previous state should only be the normal 
-                 * state since the char constant of double quote should not 
-                 * change the state. And because character constants are by 
-                 * definition only one char long, we should also never enter 
-                 * the comment state.*/
-                if (detect_state_change('\'')) {
-                    exit_state();
-                    if (get_current_state() != NORMAL) {
-                        fprintf(
-                            stderr, 
-                            "Could not parse single quotes at line %d\n",
-                            lines
-                        );
-                        exit(151);
-                    }
-                }
+				handle_singleq();
                 break;
             case DOUBLEQ:
-                /* From the double quote state we can only revert back into the 
-                 * normal state since we can't enter a comment state from within
-                 * a multi-line comment. Additionally, we can not have come from 
-                 * the single quote state. */
-                if (detect_state_change('"')) {
-                    exit_state();
-                    if (get_current_state() != NORMAL) {
-                        fprintf(
-                            stderr, 
-                            "Could not parse double quotes at %d\n",
-                            lines
-                        );
-                        exit(152);
-                    }
-                }
+				handle_doubleq();
                 break;
         }
         shift_read_character();
@@ -199,8 +229,10 @@ void trace_unbalanced()
             names[get_current_state()],
             get_line_of_state(nest_level)
         );
-        exit(153);
-    }
+        exit(156);
+    } else {
+		printf("It all looks ok!\n");
+	}
 }
 
 int main(void)

--- a/1.24.c
+++ b/1.24.c
@@ -70,13 +70,13 @@ void enter_state(int new_state)
 int state_in_stack(int state_to_check)
 {
     extern int state[MAXNESTED];
-	int i;
-	for (i = 0; i < MAXNESTED; i++) {
-		if (state[i] == state_to_check) {
-			return 1;
-		}
-	}
-	return 0;
+    int i;
+    for (i = 0; i < MAXNESTED; i++) {
+        if (state[i] == state_to_check) {
+            return 1;
+        }
+    }
+    return 0;
 }
 
 void exit_state(int state_to_exit)
@@ -84,25 +84,25 @@ void exit_state(int state_to_exit)
     /* Drop a state from the stack */
     extern int state[MAXNESTED];
     extern int nest_level;
-	if (get_current_state() != state_to_exit) {
-		fprintf(
-			stderr, 
-			"Expected to be exiting state %s but was actually exiting %s at line %d\n",
+    if (get_current_state() != state_to_exit) {
+        fprintf(
+            stderr, 
+            "Expected to be exiting state %s but was actually exiting %s at line %d\n",
             names[state_to_exit],
             names[get_current_state()],
-			lines + 1
-		);
-		exit(151);
-	}
-	if (!state_in_stack(state_to_exit)) {
-		fprintf(
-			stderr, 
-			"Closing unstarted %s at line %d\n",
+            lines + 1
+        );
+        exit(151);
+    }
+    if (!state_in_stack(state_to_exit)) {
+        fprintf(
+            stderr, 
+            "Closing unstarted %s at line %d\n",
             names[state_to_exit],
-			lines + 1
-		);
-		exit(152);
-	}
+            lines + 1
+        );
+        exit(152);
+    }
     state[nest_level] = '\0';
     nest_level--;
 }
@@ -144,83 +144,83 @@ void shift_read_character()
 
 void handle_re_entrant_state()
 {
-	/* From the a re-entrant state we can enter the comment state, 
-	 * the single quote state and the double quote state. We can also
-	 * enter the parenthesis, brackets and braces states. Those last 
-	 * three can be nested */
-	if (detect_entering_comment()) {
-		enter_state(COMMENT);
-	} else if (detect_state_change('\'')) {
-		enter_state(SINGLEQ);
-	} else if (detect_state_change('"')) {
-		enter_state(DOUBLEQ);
-	} else if (detect_state_change('(')) {
-		enter_state(PARENTH);
-	} else if (detect_state_change(')')) {
-		exit_state(PARENTH);
-	} else if (detect_state_change('[')) {
-		enter_state(BRACKET);
-	} else if (detect_state_change(']')) {
-		exit_state(BRACKET);
-	} else if (detect_state_change('{')) {
-		enter_state(CURLIES);
-	} else if (detect_state_change('}')) {
-		exit_state(CURLIES);
-	}
+    /* From the a re-entrant state we can enter the comment state, 
+     * the single quote state and the double quote state. We can also
+     * enter the parenthesis, brackets and braces states. Those last 
+     * three can be nested */
+    if (detect_entering_comment()) {
+        enter_state(COMMENT);
+    } else if (detect_state_change('\'')) {
+        enter_state(SINGLEQ);
+    } else if (detect_state_change('"')) {
+        enter_state(DOUBLEQ);
+    } else if (detect_state_change('(')) {
+        enter_state(PARENTH);
+    } else if (detect_state_change(')')) {
+        exit_state(PARENTH);
+    } else if (detect_state_change('[')) {
+        enter_state(BRACKET);
+    } else if (detect_state_change(']')) {
+        exit_state(BRACKET);
+    } else if (detect_state_change('{')) {
+        enter_state(CURLIES);
+    } else if (detect_state_change('}')) {
+        exit_state(CURLIES);
+    }
 }
 
 void handle_comment()
 {
-	/* From the comment state we can only exit back into the normal 
-	 * state. We can not have come from the comment single quote 
-	 * state and we could also not have come from the double quote state 
-	 * since those both do not allow entering the comment state. */
-	if (detect_leaving_comment()) {
-		exit_state(COMMENT);
-		if (get_current_state() == SINGLEQ || get_current_state() == DOUBLEQ) {
-			fprintf(
-				stderr, 
-				"Could not parse comment at line %d\n",
-				lines
-			);
-			exit(153);
-		}
-	}
+    /* From the comment state we can only exit back into the normal 
+     * state. We can not have come from the comment single quote 
+     * state and we could also not have come from the double quote state 
+     * since those both do not allow entering the comment state. */
+    if (detect_leaving_comment()) {
+        exit_state(COMMENT);
+        if (get_current_state() == SINGLEQ || get_current_state() == DOUBLEQ) {
+            fprintf(
+                stderr, 
+                "Could not parse comment at line %d\n",
+                lines
+            );
+            exit(153);
+        }
+    }
 }
 
 void handle_q(char delimiter, int state, int check, char msg[], int code)
 {
-	if (detect_state_change(delimiter)) {
-		exit_state(state);
-		if (get_current_state() == check) {
-			fprintf(
-					stderr, 
-					"%s at line %d\n",
-					msg, lines
-				   );
-			exit(code);
-		}
-	}
+    if (detect_state_change(delimiter)) {
+        exit_state(state);
+        if (get_current_state() == check) {
+            fprintf(
+                    stderr, 
+                    "%s at line %d\n",
+                    msg, lines
+                   );
+            exit(code);
+        }
+    }
 }
 
 void handle_singleq()
 {
-	/* From the single quote state we can exit back into the 
-	 * normal state. The previous state should only be the normal 
-	 * state since the char constant of double quote should not 
-	 * change the state. And because character constants are by 
-	 * definition only one char long, we should also never enter 
-	 * the comment state.*/
-	handle_q('\'', SINGLEQ, DOUBLEQ, "Could not parse single quotes", 151);
+    /* From the single quote state we can exit back into the 
+     * normal state. The previous state should only be the normal 
+     * state since the char constant of double quote should not 
+     * change the state. And because character constants are by 
+     * definition only one char long, we should also never enter 
+     * the comment state.*/
+    handle_q('\'', SINGLEQ, DOUBLEQ, "Could not parse single quotes", 151);
 }
 
 void handle_doubleq()
 {
-	/* From the double quote state we can only revert back into the 
-	 * normal state since we can't enter a comment state from within
-	 * a multi-line comment. Additionally, we can not have come from 
-	 * the single quote state. */
-	handle_q('"', DOUBLEQ, SINGLEQ, "Could not parse double quotes", 152);
+    /* From the double quote state we can only revert back into the 
+     * normal state since we can't enter a comment state from within
+     * a multi-line comment. Additionally, we can not have come from 
+     * the single quote state. */
+    handle_q('"', DOUBLEQ, SINGLEQ, "Could not parse double quotes", 152);
 }
 
 void initialize_state_machine()
@@ -231,16 +231,16 @@ void initialize_state_machine()
         }
         switch(get_current_state()) {
             case NORMAL: case PARENTH: case BRACKET: case CURLIES:
-				handle_re_entrant_state();
+                handle_re_entrant_state();
                 break;
             case COMMENT:
-				handle_comment();
+                handle_comment();
                 break;
             case SINGLEQ:
-				handle_singleq();
+                handle_singleq();
                 break;
             case DOUBLEQ:
-				handle_doubleq();
+                handle_doubleq();
                 break;
         }
         shift_read_character();
@@ -261,8 +261,8 @@ void trace_unbalanced()
         );
         exit(154);
     } else {
-		printf("It all looks ok!\n");
-	}
+        printf("It all looks ok!\n");
+    }
 }
 
 int main(void)

--- a/1.24.c
+++ b/1.24.c
@@ -67,12 +67,42 @@ void enter_state(int new_state)
     enterline[nest_level] = lines + 1;
 }
 
+int state_in_stack(int state_to_check)
+{
+    extern int state[MAXNESTED];
+	int i;
+	for (i = 0; i < MAXNESTED; i++) {
+		if (state[i] == state_to_check) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
 void exit_state(int state_to_exit)
 {
     /* Drop a state from the stack */
     extern int state[MAXNESTED];
     extern int nest_level;
-	/* todo: throw error when state_to_exit not in stack */
+	if (get_current_state() != state_to_exit) {
+		fprintf(
+			stderr, 
+			"Expected to be exiting state %s but was actually exiting %s at line %d\n",
+            names[state_to_exit],
+            names[get_current_state()],
+			lines + 1
+		);
+		exit(151);
+	}
+	if (!state_in_stack(state_to_exit)) {
+		fprintf(
+			stderr, 
+			"Closing unstarted %s at line %d\n",
+            names[state_to_exit],
+			lines + 1
+		);
+		exit(152);
+	}
     state[nest_level] = '\0';
     nest_level--;
 }
@@ -153,7 +183,7 @@ void handle_comment()
 				"Could not parse comment at line %d\n",
 				lines
 			);
-			exit(150);
+			exit(153);
 		}
 	}
 }
@@ -229,7 +259,7 @@ void trace_unbalanced()
             names[get_current_state()],
             get_line_of_state(nest_level)
         );
-        exit(156);
+        exit(154);
     } else {
 		printf("It all looks ok!\n");
 	}

--- a/1.24.c
+++ b/1.24.c
@@ -1,0 +1,174 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#define NORMAL 0
+#define COMMENT 1
+#define SINGLEQ 2
+#define DOUBLEQ 3
+#define PARENTH 4
+#define BRACKET 5
+#define CURLIES 6
+
+/* parse code until the C99 max nesting limit */
+#define MAXNESTED 127
+
+int lines = 0;
+int nest_level = 0;
+int state[MAXNESTED] = {'\0'};
+
+/* mark the line of every state change */
+int enterline[MAXNESTED] = {'\0'};
+
+const char *names[7] = {
+    "normal text", "comment", "single quotes",
+    "double quotes", "parenthesis", "brackets",
+    "curly braces"
+};
+
+void set_initial_state()
+{
+    extern int state[MAXNESTED];
+    state[0] = NORMAL;
+}
+
+int get_line_of_state(int level)
+{
+    extern int enterline[MAXNESTED];
+    return enterline[level];
+}
+
+int get_current_state()
+{
+    extern int state[MAXNESTED];
+    extern int nest_level;
+    return state[nest_level];
+}
+
+void enter_state(int new_state)
+{
+    /* Add a new state to the stack */
+    extern int state[MAXNESTED];
+    extern int enterline[MAXNESTED];
+    extern int lines;
+    nest_level++;
+    if (nest_level >= MAXNESTED) {
+        fprintf(
+            stderr, 
+            "C99 can only nest control up to 127 times. At line %d\n",
+            lines
+        );
+        exit(150);
+    }
+    state[nest_level] = new_state;
+    enterline[nest_level] = lines + 1;
+}
+
+void exit_state()
+{
+    /* Drop a state from the stack */
+    extern int state[MAXNESTED];
+    extern int nest_level;
+    state[nest_level] = '\0';
+    nest_level--;
+}
+
+
+int main(void)
+{
+    /* Simple state machine to check a C program for rudimentary syntax errors */
+    extern int nest_level;
+    extern int lines;
+    extern const char *names[7];
+    int c;
+    int prevprevchar = '\0';
+    int prevchar = '\0';
+
+    set_initial_state();
+
+    while ((c = getchar()) != EOF) {
+        if (c == '\n') {
+            lines++;
+        }
+        switch(get_current_state()) {
+            case NORMAL:
+                /* From the normal state we can enter the comment state, 
+                 * the single quote state and the double quote state. */
+                if (prevprevchar != '\\' && prevchar == '/' && c == '*') {
+                    enter_state(COMMENT);
+                } else if (prevchar != '\\' && c == '\'') {
+                    enter_state(SINGLEQ);
+                } else if (prevchar != '\\' && c == '"') {
+                    enter_state(DOUBLEQ);
+                }
+                break;
+            case COMMENT:
+                /* From the comment state we can only exit back into the normal 
+                 * state. We can not have come from the comment single quote 
+                 * state and we could also not have come from the double quote state 
+                 * since those both do not allow entering the comment state. */
+                if (prevchar == '*' && c == '/') {
+                    exit_state();
+                    if (get_current_state() != NORMAL) {
+                        fprintf(
+                            stderr, 
+                            "Could not parse comment at line %d\n",
+                            lines
+                        );
+                        exit(150);
+                    }
+                }
+                break;
+            case SINGLEQ:
+                /* From the single quote state we can exit back into the 
+                 * normal state. The previous state should only be the normal 
+                 * state since the char constant of double quote should not 
+                 * change the state. And because character constants are by 
+                 * definition only one char long, we should also never enter 
+                 * the comment state.*/
+                if (c == '\'') {
+                    if (prevchar != '\\' || prevprevchar == '\\') {
+                        exit_state();
+                        if (get_current_state() != NORMAL) {
+                            fprintf(
+                                stderr, 
+                                "Could not parse single quotes at line %d\n",
+                                lines
+                            );
+                            exit(150);
+                        }
+                    }
+                }
+                break;
+            case DOUBLEQ:
+                /* From the double quote state we can only revert back into the 
+                 * normal state since we can't enter a comment state from within
+                 * a multi-line comment. Additionally, we can not have come from 
+                 * the single quote state. */
+                if (c == '"') {
+                    if (prevchar != '\\' || prevprevchar == '\\') {
+                        exit_state();
+                        if (get_current_state() != NORMAL) {
+                            fprintf(
+                                stderr, 
+                                "Could not parse double quotes at %d\n",
+                                lines
+                            );
+                            exit(150);
+                        }
+                    }
+                }
+                break;
+        }
+        prevprevchar = prevchar;
+        prevchar = c;
+    }
+    if (nest_level != 0) {
+        fprintf(
+            stderr, 
+            "Unbalanced %s at line %d\n",
+            names[get_current_state()],
+            get_line_of_state(nest_level)
+        );
+    }
+    return 0;
+}

--- a/test_1_24.py
+++ b/test_1_24.py
@@ -1,0 +1,188 @@
+from tempfile import NamedTemporaryFile
+from subprocess import Popen, check_call, PIPE
+from unittest import TestCase
+
+
+class TestExercise124(TestCase):
+    @staticmethod
+    def run_against_text(text):
+        with NamedTemporaryFile() as fh:
+            fh.write(text)
+            fh.flush()
+            command = 'cat {} | ./a.out'.format(fh.name)
+            process = Popen(command, shell=True, stdout=PIPE, stderr=PIPE)
+            standard_out, standard_error = process.communicate()
+            exit_code = process.returncode
+        return standard_out, standard_error, exit_code
+
+    def setUp(self):
+        print("Compiling 1.24")
+        check_call(['gcc', '1.24.c'])
+
+    def test_detect_syntax_errors(self):
+        print('Testing if valid C file returns OK')
+        code = """
+#include <stdio.h>
+int main(void)
+{
+    /* Simple state machine for parsing multi-line comments from C code */
+    return 0;
+}
+        """
+        standard_out_output, standard_error_output, exit_code = self.run_against_text(code)
+
+        expected_output = 'It all looks ok!\n'
+        self.assertEqual(standard_out_output, expected_output)
+
+        print('Testing if a missing closing parenthesis is detected')
+        code = """
+#include <stdio.h>
+int main(void)
+{
+    /* Simple state machine for parsing multi-line comments from C code */
+    int a = (a +;
+    return 0;
+}
+        """
+        standard_out_output, standard_error_output, exit_code = self.run_against_text(code)
+
+        expected_output = 'Expected to be exiting state curly braces but was actually exiting parenthesis at line 8\n'
+        self.assertEqual(standard_error_output, expected_output)
+
+        print('Testing if a missing closing bracket is detected')
+        code = """
+#include <stdio.h>
+int main(void)
+{
+    /* Simple state machine for parsing multi-line comments from C code */
+    int a[0 = 2;
+    return 0;
+}
+        """
+        standard_out_output, standard_error_output, exit_code = self.run_against_text(code)
+
+        expected_output = 'Expected to be exiting state curly braces but was actually exiting brackets at line 8\n'
+        self.assertEqual(standard_error_output, expected_output)
+
+        print('Testing if a missing closing curly is detected')
+        code = """
+#include <stdio.h>
+int main(void)
+{
+    /* Simple state machine for parsing multi-line comments from C code */
+    int a;
+    if (1 == 1) {
+        a = 2;
+}
+        """
+        standard_out_output, standard_error_output, exit_code = self.run_against_text(code)
+
+        expected_output = 'Unbalanced curly braces at line 4\n'
+        self.assertEqual(standard_error_output, expected_output)
+
+        print('Testing if a missing opening parenthesis is detected')
+        code = """
+#include <stdio.h>
+int main(void)
+{
+    /* Simple state machine for parsing multi-line comments from C code */
+    int a = a + 2);
+    return 0;
+}
+        """
+        standard_out_output, standard_error_output, exit_code = self.run_against_text(code)
+
+        expected_output = 'Expected to be exiting state parenthesis but was actually exiting curly braces at line 6\n'
+        self.assertEqual(standard_error_output, expected_output)
+
+        print('Testing if a missing opening bracket is detected')
+        code = """
+#include <stdio.h>
+int main(void)
+{
+    /* Simple state machine for parsing multi-line comments from C code */
+    int a2] = 2;
+    return 0;
+}
+        """
+        standard_out_output, standard_error_output, exit_code = self.run_against_text(code)
+
+        expected_output = 'Expected to be exiting state brackets but was actually exiting curly braces at line 6\n'
+        self.assertEqual(standard_error_output, expected_output)
+
+        print('Testing if a missing opening curly is detected')
+        code = """
+#include <stdio.h>
+int main(void)
+{
+    /* Simple state machine for parsing multi-line comments from C code */
+    int a;
+    if (1 == 1)
+        a = 2;
+    }
+    return 0;
+}
+        """
+        standard_out_output, standard_error_output, exit_code = self.run_against_text(code)
+
+        expected_output = 'Expected to be exiting state curly braces but was actually exiting normal text at line 11\n'
+        self.assertEqual(standard_error_output, expected_output)
+
+        print('Testing if an unclosed comment is detected')
+        code = """
+#include <stdio.h>
+int main(void)
+{
+    /* Simple state machine for parsing multi-line comments from C code
+    return 0;
+}
+        """
+        standard_out_output, standard_error_output, exit_code = self.run_against_text(code)
+
+        expected_output = 'Unbalanced comment at line 5\n'
+        self.assertEqual(standard_error_output, expected_output)
+
+        print('Testing if unopened single quotes are detected')
+        code = """
+#include <stdio.h>
+int main(void)
+{
+    /* Simple state machine for parsing multi-line comments from C code */
+    char a = a';
+    return 0;
+}
+        """
+        standard_out_output, standard_error_output, exit_code = self.run_against_text(code)
+
+        expected_output = 'Unbalanced single quotes at line 6\n'
+        self.assertEqual(standard_error_output, expected_output)
+
+        print('Testing if unclosed double quotes are detected')
+        code = """
+#include <stdio.h>
+int main(void)
+{
+    /* Simple state machine for parsing multi-line comments from C code */
+    char *a = "abc;
+    return 0;
+}
+        """
+        standard_out_output, standard_error_output, exit_code = self.run_against_text(code)
+
+        expected_output = 'Unbalanced double quotes at line 6\n'
+        self.assertEqual(standard_error_output, expected_output)
+
+        print('Testing if unopened double quotes are detected')
+        code = """
+#include <stdio.h>
+int main(void)
+{
+    /* Simple state machine for parsing multi-line comments from C code */
+    char *a = abc";
+    return 0;
+}
+        """
+        standard_out_output, standard_error_output, exit_code = self.run_against_text(code)
+
+        expected_output = 'Unbalanced double quotes at line 6\n'
+        self.assertEqual(standard_error_output, expected_output)


### PR DESCRIPTION
my solution to exercise 1.24 from The C Programming Language" (2nd edition) by Brian W. Kernighan and Dennis M. Ritchie, also referred to as K&R.

> exercise 1.24
> Write a program to check a C program for rudimentary syntax errors like unbalanced parentheses, brackets and braces.
> Don't forget about quotes, both single and double, escape sequences, and comments. (This program is hard if you do it in full generality.)

```
vdloo@workstation2:~/code/projects/k-r$ grep -n '"' 1.22.c
43:            printf("\n");
53:            printf("-\n);
57:        printf("%c", s[i]);
vdloo@workstation2:~/code/projects/k-r$ cat 1.22.c | ./a.out
Unbalanced double quotes at line 57
```
